### PR TITLE
Default token value

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function safeFetch(url, options) {
         options.credentials = 'same-origin';
     }
     if (options.credentials === 'same-origin') {
-        token = Cookies.get(safeFetch.cookieName);
+        token = Cookies.get(safeFetch.cookieName) || '';
         options.headers = options.headers || {};
         options.headers[safeFetch.headerName] = token;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -65,4 +65,10 @@ describe('safe fetch', () => {
         assert.deepStrictEqual(global.fetch.firstCall.args[1].headers, { 'x-my-header-name': TEST_TOKEN });
     });
 
+    it('should always have a value for the header', () => {
+        global.fetch = sinon.spy();
+        Cookies.get = () => undefined;
+        safeFetch(TEST_URL);
+        assert.equal(global.fetch.firstCall.args[1].headers['x-csrf-token'], '');
+    });
 });


### PR DESCRIPTION
If the cookie is not set, it will be undefined. Some fetch-polyfills
fail on a header with an undefined value. Therefore it defaults to the
empty string now.
